### PR TITLE
Remake start function

### DIFF
--- a/functions/start.mcfunction
+++ b/functions/start.mcfunction
@@ -1,5 +1,4 @@
 ## Meant to be used on first load, this enables the first user with the "Owner" role and then this function wont work anymore.
-
 tellraw @s {"rawtext":[{"text":"§l§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§r"}]}
 tellraw @s {"rawtext":[{"text":"§l§fWelcome to Rubedo!§r"}]}
 tellraw @s {"rawtext":[{"text":"§f§lThe Most Advanced Anti-cheat for your realms/worlds/servers"}]}
@@ -10,4 +9,6 @@ tellraw @s {"rawtext":[{"text":"§b§oTip: For Documentation Check github.com/sm
 tellraw @s {"rawtext":[{"text":"§l§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§9-§f-§r"}]}
 
 effect @s darkness 3 255 true
+tag @s add CHECK
 event entity @s "rubedo:becomeAdmin"
+tellraw @s[tag=CHECK] {"rawtext":[{"text":"§cCannot give admin: Put Rubedo above another behaivor packs"}]}

--- a/src/plugins/Anti-Cheat/modules/events/beforeDataDrivenEntityTriggerEvent.ts
+++ b/src/plugins/Anti-Cheat/modules/events/beforeDataDrivenEntityTriggerEvent.ts
@@ -2,14 +2,12 @@ import { Player, world } from "@minecraft/server";
 import { setRole, setServerOwner } from "../../utils";
 
 let e = world.events.beforeDataDrivenEntityTriggerEvent.subscribe((data) => {
-  if (world.getDynamicProperty("roleHasBeenSet"))
-    return world.events.beforeDataDrivenEntityTriggerEvent.unsubscribe(e);
-  if (!(data.entity instanceof Player)) return;
-  if (data.id != "rubedo:becomeAdmin") return;
-  setRole(data.entity, "admin");
-  world.setDynamicProperty("roleHasBeenSet", true);
-  setServerOwner(data.entity)
-  data.entity.tell(
-    `§l§cYou have been given admin, the function start will not work anymore!!!!`
-  );
+	if (world.getDynamicProperty("roleHasBeenSet")) return world.events.beforeDataDrivenEntityTriggerEvent.unsubscribe(e);
+	if (!(data.entity instanceof Player)) return;
+	if (data.id != "rubedo:becomeAdmin") return;
+	data.entity.removeTag("CHECK");
+	setRole(data.entity, "admin");
+	world.setDynamicProperty("roleHasBeenSet", true);
+	setServerOwner(data.entity);
+	data.entity.tell(`§l§cYou have been given admin, the function start will not work anymore!!!!`);
 });


### PR DESCRIPTION
Remake the start function. Many players forget that Rubedo should be higher than the other behavior packs, so the start function simply does not give out the admin role. Im added a warning when the player did not place the Rubedo above the other packs.